### PR TITLE
ExternalStatusService: run status update off the main thread

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.IBinder;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.eveningoutpost.dexdrip.models.APStatus;
 import com.eveningoutpost.dexdrip.models.JoH;
@@ -13,7 +14,9 @@ import com.eveningoutpost.dexdrip.NewDataObserver;
 import com.eveningoutpost.dexdrip.utilitymodels.Constants;
 import com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
+import com.eveningoutpost.dexdrip.utils.jobs.BackgroundQueue;
 
+import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 
 import lombok.val;
@@ -30,6 +33,13 @@ public class ExternalStatusService extends android.app.Service {
     //public static final String RECEIVER_PERMISSION = "com.eveningoutpost.dexdrip.permissions.RECEIVE_EXTERNAL_STATUSLINE";
     private static final int MAX_LEN = 70;
     private final static String TAG = ExternalStatusService.class.getSimpleName();
+
+    // onStartCommand runs on the main thread; update() does synchronous SQLite I/O, so it is
+    // dispatched here. BackgroundQueue is xDrip's sequential background processor, so it preserves
+    // the ordering the old IntentService gave us (avoids overlapping broadcasts racing
+    // createEfficientRecord()'s read-then-write).
+    @VisibleForTesting
+    static Executor dispatchExecutor = BackgroundQueue::post;
 
     @Override
     public void onCreate() {
@@ -49,10 +59,15 @@ public class ExternalStatusService extends android.app.Service {
             final String action = intent.getAction();
             if (ACTION_NEW_EXTERNAL_STATUSLINE.equals(action)) {
                 final String statusLine = intent.getStringExtra(EXTRA_STATUSLINE);
-                update(JoH.tsl(), statusLine, true);
+                final long timestamp = JoH.tsl(); // capture arrival time on the calling thread
+                dispatchExecutor.execute(() -> {
+                    update(timestamp, statusLine, true);
+                    stopSelf(startId);
+                });
+                return START_NOT_STICKY;
             }
         }
-        stopSelf();
+        stopSelf(startId);
         return START_NOT_STICKY;
     }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusServiceTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/wearintegration/ExternalStatusServiceTest.java
@@ -9,17 +9,55 @@ import static com.eveningoutpost.dexdrip.wearintegration.ExternalStatusService.g
 import static com.eveningoutpost.dexdrip.wearintegration.ExternalStatusService.getTBRInt;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import android.app.Service;
+import android.content.Intent;
+
 import com.eveningoutpost.dexdrip.models.JoH;
 import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
 import com.eveningoutpost.dexdrip.utilitymodels.PersistentStore;
 
+import org.junit.After;
 import org.junit.Test;
+import org.robolectric.Robolectric;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import lombok.val;
 
 // jamorham
 
 public class ExternalStatusServiceTest extends RobolectricTestWithConfig {
+
+    private final Executor originalDispatchExecutor = ExternalStatusService.dispatchExecutor;
+
+    @After
+    public void restoreDispatchExecutor() {
+        ExternalStatusService.dispatchExecutor = originalDispatchExecutor;
+    }
+
+    /**
+     * Off {@code IntentService}, {@code onStartCommand} runs on the main thread. The status update
+     * does synchronous SQLite I/O, so it must be handed to the background executor rather than run
+     * inline on the calling thread. This captures the scheduled work without running it to prove it
+     * is deferred.
+     */
+    @Test
+    public void onStartCommandDefersStatusUpdateToExecutor() {
+        val scheduled = new ArrayList<Runnable>();
+        ExternalStatusService.dispatchExecutor = scheduled::add;
+
+        val intent = new Intent(ExternalStatusService.ACTION_NEW_EXTERNAL_STATUSLINE);
+        val service = Robolectric.buildService(ExternalStatusService.class, intent).create().get();
+
+        val result = service.onStartCommand(intent, 0, 42);
+
+        assertWithMessage("status update must be handed to the executor, not executed inline on the calling thread")
+                .that(scheduled).hasSize(1);
+        assertWithMessage("service should not be sticky")
+                .that(result).isEqualTo(Service.START_NOT_STICKY);
+    }
 
     final String tbr1 =  "Loop Disabled\n10% 0.55U 0g"; // typical
     final String tbr2 =  "Loop Disabled\n999% 15% 0.55U 0g"; // weird


### PR DESCRIPTION
Off `IntentService`, `onStartCommand` runs on the main thread, so `update()` did synchronous SQLite I/O (`APStatus` read-then-write) there on every AAPS `ExternalStatusline` broadcast. This dispatches it to `BackgroundQueue` — xDrip's own sequential background processor — so the DB work stays off the main thread while preserving the old `IntentService`'s sequential ordering (no overlapping broadcasts racing `createEfficientRecord()`'s read-then-write). Also switches `stopSelf()` → `stopSelf(startId)`.

Verified on an API 34 emulator: the `APStatus` insert now runs on a background thread where before it ran on the main thread (confirmed via the logging tid vs the main tid). Adds a unit test for the dispatch.

This is the fix for the regression I mentioned — feel free to test it yourself and adjust as needed.