### PR TITLE
Remove notification-channel helpers left unused by this PR

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
@@ -155,14 +155,6 @@ public class NotificationChannels {
 
     }
 
-    private static boolean addChannelGroup() {
-        // If notifications are grouped, the BG number icon doesn't update
-        if (Pref.getBooleanDefaultFalse("use_number_icon")) {
-            return false;
-        }
-        return Pref.getBooleanDefaultFalse("notification_channels_grouping");
-    }
-
     @TargetApi(26)
     public static NotificationChannel getChan(NotificationCompat.Builder wip) {
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/Notifications.java
@@ -568,12 +568,6 @@ public class Notifications extends IntentService {
                 .build();
     }*/
 
-    private boolean useOngoingChannel() {
-        return (Pref.getBooleanDefaultFalse("use_notification_channels") &&
-                Pref.getBooleanDefaultFalse("ongoing_notification_channel") &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
-    }
-
     //@TargetApi(Build.VERSION_CODES.O)
     public synchronized Notification createOngoingNotification(BgGraphBuilder bgGraphBuilder, Context context) {
         mContext = context;


### PR DESCRIPTION
Small follow-up cleanup: `NotificationChannels.addChannelGroup()` and `Notifications.useOngoingChannel()` became unreachable when this PR removed their call sites (the channel-grouping logic and the `use_notification_channels` ongoing gate). Removing the two now-dead private methods. Compiles clean, full `./gradlew test` green, no behaviour change.