### PR TITLE
Notification channels: fall back to a channel that exists, and name the new ones

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannels.java
@@ -75,6 +75,8 @@ public class NotificationChannels {
         map.put(BG_PERSISTENT_HIGH_CHANNEL, xdrip.getAppContext().getString(R.string.persistent_high_alert));
         map.put(CALIBRATION_CHANNEL, xdrip.getAppContext().getString(R.string.calibration_alerts));
         map.put(ONGOING_CHANNEL, "Ongoing Notification");
+        map.put(GENERAL_CHANNEL, "General");
+        map.put(SENSOR_EXPIRY_CHANNEL, "Sensor expiry");
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompat.java
@@ -18,8 +18,10 @@ public class XdripNotificationCompat extends NotificationCompat {
         try {
             id = NotificationChannels.getChan(builder).getId();
         } catch (Exception e) {
-            // Fallback to generic alert channel if the guesser fails
-            id = NotificationChannels.BG_ALERT_CHANNEL;
+            // Fallback to the general channel if the guesser fails. It has to be created here:
+            // from API 26 a notification posted to a channel that does not exist is silently dropped.
+            NotificationChannels.setupGeneralChannel();
+            id = NotificationChannels.GENERAL_CHANNEL;
         }
         builder.setChannelId(id);
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -1,8 +1,11 @@
 package com.eveningoutpost.dexdrip.utilitymodels;
 
+import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.GENERAL_CHANNEL;
+import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.SENSOR_EXPIRY_CHANNEL;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 
 import androidx.core.app.NotificationCompat;
 
@@ -15,6 +18,8 @@ import lombok.val;
 
 public class NotificationChannelsTest extends RobolectricTestWithConfig {
     private static final long[] pattern = {123, 456, 789};
+    private static final String GENERAL_NAME = "General";
+    private static final String SENSOR_EXPIRY_NAME = "Sensor expiry";
 
     @Test
     public void getNotificationFromInsideBuilderTest() {
@@ -24,5 +29,48 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
         assertWithMessage("got builder by reflection 1").that(mNotification).isNotNull();
         assertWithMessage("got builder by reflection 2").that(mNotification.getClass()).isEqualTo(Notification.class);
         assertWithMessage("got builder by reflection 3").that(mNotification.vibrate).isEqualTo(pattern);
+    }
+
+    // display names: a channel missing from the name map falls back to showing its raw id
+
+    @Test
+    public void getStringReturnsDisplayNameForSensorExpiryChannel() {
+        assertWithMessage("sensor expiry channel display name")
+                .that(NotificationChannels.getString(SENSOR_EXPIRY_CHANNEL))
+                .isEqualTo(SENSOR_EXPIRY_NAME);
+    }
+
+    @Test
+    public void getStringReturnsDisplayNameForGeneralChannel() {
+        assertWithMessage("general channel display name")
+                .that(NotificationChannels.getString(GENERAL_CHANNEL))
+                .isEqualTo(GENERAL_NAME);
+    }
+
+    // the channel a notification is actually posted to: getChan appends a hash of the
+    // sound / vibration / lights to both the id and the name of the channel it creates
+
+    @Test
+    public void getChanNamesSensorExpiryChannelAfterItsDisplayName() {
+        val channel = getChanFor(SENSOR_EXPIRY_CHANNEL);
+        assertWithMessage("sensor expiry channel id").that(channel.getId()).startsWith(SENSOR_EXPIRY_CHANNEL);
+        assertWithMessage("sensor expiry channel name").that(channel.getName().toString()).startsWith(SENSOR_EXPIRY_NAME);
+    }
+
+    @Test
+    public void getChanNamesGeneralChannelAfterItsDisplayName() {
+        val channel = getChanFor(GENERAL_CHANNEL);
+        assertWithMessage("general channel id").that(channel.getId()).startsWith(GENERAL_CHANNEL);
+        assertWithMessage("general channel name").that(channel.getName().toString()).startsWith(GENERAL_NAME);
+    }
+
+    /** Builds a notification the way {@code JoH.showNotification} does, with vibration and lights. */
+    private NotificationChannel getChanFor(final String channelId) {
+        val builder = new NotificationCompat.Builder(RuntimeEnvironment.getApplication().getApplicationContext(), channelId);
+        builder.setContentTitle("title");
+        builder.setContentText("content");
+        builder.setVibrate(pattern);
+        builder.setLights(0xff00ff00, 300, 1000);
+        return NotificationChannels.getChan(builder);
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/NotificationChannelsTest.java
@@ -5,7 +5,6 @@ import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.SENS
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
 
 import androidx.core.app.NotificationCompat;
 
@@ -35,16 +34,20 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
 
     @Test
     public void getStringReturnsDisplayNameForSensorExpiryChannel() {
-        assertWithMessage("sensor expiry channel display name")
-                .that(NotificationChannels.getString(SENSOR_EXPIRY_CHANNEL))
-                .isEqualTo(SENSOR_EXPIRY_NAME);
+        // :: Act
+        val name = NotificationChannels.getString(SENSOR_EXPIRY_CHANNEL);
+
+        // :: Verify
+        assertWithMessage("sensor expiry channel display name").that(name).isEqualTo(SENSOR_EXPIRY_NAME);
     }
 
     @Test
     public void getStringReturnsDisplayNameForGeneralChannel() {
-        assertWithMessage("general channel display name")
-                .that(NotificationChannels.getString(GENERAL_CHANNEL))
-                .isEqualTo(GENERAL_NAME);
+        // :: Act
+        val name = NotificationChannels.getString(GENERAL_CHANNEL);
+
+        // :: Verify
+        assertWithMessage("general channel display name").that(name).isEqualTo(GENERAL_NAME);
     }
 
     // the channel a notification is actually posted to: getChan appends a hash of the
@@ -52,25 +55,37 @@ public class NotificationChannelsTest extends RobolectricTestWithConfig {
 
     @Test
     public void getChanNamesSensorExpiryChannelAfterItsDisplayName() {
-        val channel = getChanFor(SENSOR_EXPIRY_CHANNEL);
+        // :: Setup
+        val builder = notificationOn(SENSOR_EXPIRY_CHANNEL);
+
+        // :: Act
+        val channel = NotificationChannels.getChan(builder);
+
+        // :: Verify
         assertWithMessage("sensor expiry channel id").that(channel.getId()).startsWith(SENSOR_EXPIRY_CHANNEL);
         assertWithMessage("sensor expiry channel name").that(channel.getName().toString()).startsWith(SENSOR_EXPIRY_NAME);
     }
 
     @Test
     public void getChanNamesGeneralChannelAfterItsDisplayName() {
-        val channel = getChanFor(GENERAL_CHANNEL);
+        // :: Setup
+        val builder = notificationOn(GENERAL_CHANNEL);
+
+        // :: Act
+        val channel = NotificationChannels.getChan(builder);
+
+        // :: Verify
         assertWithMessage("general channel id").that(channel.getId()).startsWith(GENERAL_CHANNEL);
         assertWithMessage("general channel name").that(channel.getName().toString()).startsWith(GENERAL_NAME);
     }
 
     /** Builds a notification the way {@code JoH.showNotification} does, with vibration and lights. */
-    private NotificationChannel getChanFor(final String channelId) {
+    private NotificationCompat.Builder notificationOn(final String channelId) {
         val builder = new NotificationCompat.Builder(RuntimeEnvironment.getApplication().getApplicationContext(), channelId);
         builder.setContentTitle("title");
         builder.setContentText("content");
         builder.setVibrate(pattern);
         builder.setLights(0xff00ff00, 300, 1000);
-        return NotificationChannels.getChan(builder);
+        return builder;
     }
 }

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
@@ -17,11 +17,13 @@ import org.robolectric.RuntimeEnvironment;
 import lombok.val;
 
 /**
+ * Tests for {@link XdripNotificationCompat}.
+ * <p>
  * From API 26 a notification posted to a channel that does not exist is silently dropped, so every
  * notification {@link XdripNotificationCompat#build} hands back must carry a channel that has
  * actually been created.
  *
- * @author Asbjørn Aarrestad - asbjorn@aarrestad.com - 2026.07
+ * @author Asbjørn Aarrestad - 2026.07
  */
 public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
 
@@ -29,8 +31,13 @@ public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
 
     @Test
     public void buildUsesTheChannelDerivedFromTheBuilder() {
-        val notification = XdripNotificationCompat.build(builderOn(SENSOR_EXPIRY_CHANNEL));
+        // :: Setup
+        val builder = builderOn(SENSOR_EXPIRY_CHANNEL);
 
+        // :: Act
+        val notification = XdripNotificationCompat.build(builder);
+
+        // :: Verify
         assertWithMessage("channel derived from the builder")
                 .that(notification.getChannelId()).startsWith(SENSOR_EXPIRY_CHANNEL);
         assertChannelExists(notification.getChannelId());
@@ -40,16 +47,26 @@ public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
 
     @Test
     public void buildFallsBackToTheGeneralChannelWhenTheBuilderHasNoChannel() {
-        val notification = XdripNotificationCompat.build(builderOn(null));
+        // :: Setup
+        val builder = builderOn(null);
 
+        // :: Act
+        val notification = XdripNotificationCompat.build(builder);
+
+        // :: Verify
         assertWithMessage("fallback channel")
                 .that(notification.getChannelId()).isEqualTo(GENERAL_CHANNEL);
     }
 
     @Test
     public void buildCreatesTheFallbackChannelItPostsTo() {
-        val notification = XdripNotificationCompat.build(builderOn(null));
+        // :: Setup
+        val builder = builderOn(null);
 
+        // :: Act
+        val notification = XdripNotificationCompat.build(builder);
+
+        // :: Verify
         assertChannelExists(notification.getChannelId());
     }
 

--- a/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/utilitymodels/XdripNotificationCompatTest.java
@@ -1,0 +1,70 @@
+package com.eveningoutpost.dexdrip.utilitymodels;
+
+import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.GENERAL_CHANNEL;
+import static com.eveningoutpost.dexdrip.utilitymodels.NotificationChannels.SENSOR_EXPIRY_CHANNEL;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import android.app.NotificationManager;
+import android.content.Context;
+
+import androidx.core.app.NotificationCompat;
+
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import lombok.val;
+
+/**
+ * From API 26 a notification posted to a channel that does not exist is silently dropped, so every
+ * notification {@link XdripNotificationCompat#build} hands back must carry a channel that has
+ * actually been created.
+ *
+ * @author Asbjørn Aarrestad - asbjorn@aarrestad.com - 2026.07
+ */
+public class XdripNotificationCompatTest extends RobolectricTestWithConfig {
+
+    private static final long[] pattern = {123, 456, 789};
+
+    @Test
+    public void buildUsesTheChannelDerivedFromTheBuilder() {
+        val notification = XdripNotificationCompat.build(builderOn(SENSOR_EXPIRY_CHANNEL));
+
+        assertWithMessage("channel derived from the builder")
+                .that(notification.getChannelId()).startsWith(SENSOR_EXPIRY_CHANNEL);
+        assertChannelExists(notification.getChannelId());
+    }
+
+    // fallback: the builder carries no channel, so getChan() cannot derive one
+
+    @Test
+    public void buildFallsBackToTheGeneralChannelWhenTheBuilderHasNoChannel() {
+        val notification = XdripNotificationCompat.build(builderOn(null));
+
+        assertWithMessage("fallback channel")
+                .that(notification.getChannelId()).isEqualTo(GENERAL_CHANNEL);
+    }
+
+    @Test
+    public void buildCreatesTheFallbackChannelItPostsTo() {
+        val notification = XdripNotificationCompat.build(builderOn(null));
+
+        assertChannelExists(notification.getChannelId());
+    }
+
+    private NotificationCompat.Builder builderOn(final String channelId) {
+        val builder = new NotificationCompat.Builder(RuntimeEnvironment.getApplication().getApplicationContext(), channelId);
+        builder.setContentTitle("title");
+        builder.setContentText("content");
+        builder.setVibrate(pattern);
+        return builder;
+    }
+
+    private void assertChannelExists(final String channelId) {
+        val manager = (NotificationManager) RuntimeEnvironment.getApplication()
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+        assertWithMessage("channel '" + channelId + "' exists, otherwise the notification is dropped")
+                .that(manager.getNotificationChannel(channelId)).isNotNull();
+    }
+}


### PR DESCRIPTION
Two fixes on top of #4628.

**The fallback in `XdripNotificationCompat` posts to a channel that does not exist.**

When `getChan()` fails, `build()` falls back to `BG_ALERT_CHANNEL`. That id is never created — `getChan()` only creates channels with a hash suffix, so the device has `bgAlertChannel  📳`, not `bgAlertChannel`. From API 26 a notification posted to a channel that does not exist is silently dropped, the same mechanism behind the sensor expiry bug this PR fixes.

The fallback is not limited to notifications built without a channel. `getChan()` also fails if the reflection in `getNotificationFromInsideBuilder()` stops working, and every notification then takes that path, glucose alerts included.

The fallback now uses `GENERAL_CHANNEL` and creates it, matching what the constant is documented for: "This should be used for all existing notifications that have null for their channel."

**The two new channels are missing from `initialize_name_map()`.**

The channel `getChan()` posts to therefore appears in the Android notification settings under its raw id — `sensorExpiryChannel  🎵📳💡` — rather than a name. `bgAlertChannel` reads "Glucose Level Alert  📳" because it is in the map.

Both are added with the names they already have where they are created, so the two agree. No new string resources: `General` and `Sensor expiry` are literals, as `Nightscout` and `Ongoing Notification` already are in the same method.

**Tests**

Robolectric, in `NotificationChannelsTest` and a new `XdripNotificationCompatTest`. Without the fixes they fail with:

```
buildFallsBackToTheGeneralChannelWhenTheBuilderHasNoChannel  expected: generalChannel  but was: bgAlertChannel
buildCreatesTheFallbackChannelItPostsTo                      expected not to be: null      <- the channel does not exist
getChanNamesSensorExpiryChannelAfterItsDisplayName           expected to start with: Sensor expiry  but was: sensorExpiryChannel  📳💡
```

Full `./gradlew test` green.
