### PR TITLE
Guard service starts against the background start restriction

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/models/JoH.java
@@ -1360,7 +1360,15 @@ public class JoH {
     }
 
     public static void startService(Class c) {
-        xdrip.getAppContext().startService(new Intent(xdrip.getAppContext(), c));
+        final Intent intent = new Intent(xdrip.getAppContext(), c);
+        try {
+            xdrip.getAppContext().startService(intent);
+        } catch (Exception e) {
+            // from target sdk 26 this throws if we are in the background, eg started only for a broadcast
+            if (ratelimit("service-start-refused", 3600)) {
+                UserError.Log.e(TAG, "Could not start service: " + c.getSimpleName() + " " + e);
+            }
+        }
     }
 
     public static void startService(final Class c, final String... args) {
@@ -1378,7 +1386,14 @@ public class JoH {
         for (int i = 0; i < args.length; i += 2) {
             intent.putExtra(args[i], args[i + 1]);
         }
-        xdrip.getAppContext().startService(intent);
+        try {
+            xdrip.getAppContext().startService(intent);
+        } catch (Exception e) {
+            // from target sdk 26 this throws if we are in the background, eg started only for a broadcast
+            if (ratelimit("service-start-refused", 3600)) {
+                UserError.Log.e(TAG, "Could not start service: " + c.getSimpleName() + " " + e);
+            }
+        }
     }
 
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/ActivityRecognizedService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/ActivityRecognizedService.java
@@ -90,7 +90,14 @@ public class ActivityRecognizedService extends IntentService implements GoogleAp
         if (d) Log.d(TAG, "Start Activity called");
         final Intent intent = new Intent(context, ActivityRecognizedService.class);
         intent.putExtra(ActivityRecognizedService.START_ACTIVITY_ACTION, ActivityRecognizedService.START_ACTIVITY_ACTION);
-        context.startService(intent);
+        try {
+            context.startService(intent);
+        } catch (Exception e) {
+            // from target sdk 26 this throws if we are in the background, eg started only for a broadcast
+            if (JoH.ratelimit("service-start-refused", 3600)) {
+                UserError.Log.e(TAG, "Could not start activity recogniser: " + e);
+            }
+        }
     }
 
     public static void reStartActivityRecogniser(Context context) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeter.java
@@ -1135,7 +1135,14 @@ public class BluetoothGlucoseMeter extends Service {
         } else {
             start_intent.putExtra("service_action", "scan");
         }
-        xdrip.getAppContext().startService(start_intent);
+        try {
+            xdrip.getAppContext().startService(start_intent);
+        } catch (Exception e) {
+            // from target sdk 26 this throws if we are in the background, eg started only for a broadcast
+            if (JoH.ratelimit("service-start-refused", 3600)) {
+                UserError.Log.e(TAG, "Could not start meter service: " + e);
+            }
+        }
     }
 
     // remote api for forgetting

--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/PlusSyncService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/PlusSyncService.java
@@ -13,6 +13,8 @@ import android.util.Log;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.GoogleDriveInterface;
 import com.eveningoutpost.dexdrip.cloud.jamcm.Pusher;
+import com.eveningoutpost.dexdrip.models.JoH;
+import com.eveningoutpost.dexdrip.models.UserError;
 import com.eveningoutpost.dexdrip.utilitymodels.UpdateActivity;
 import com.eveningoutpost.dexdrip.xdrip;
 
@@ -54,7 +56,15 @@ public class PlusSyncService extends Service {
         }
         if ((GcmActivity.token != null) && (xdrip.getAppContext() != null)) return;
         Log.d(TAG, "Starting jamorham xDrip-Plus sync service: " + source);
-        context.startService(new Intent(context, PlusSyncService.class));
+        final Intent intent = new Intent(context, PlusSyncService.class);
+        try {
+            context.startService(intent);
+        } catch (Exception e) {
+            // from target sdk 26 this throws if we are in the background, eg started only for a broadcast
+            if (JoH.ratelimit("service-start-refused", 3600)) {
+                UserError.Log.e(TAG, "Could not start sync service: " + e);
+            }
+        }
     }
 
     public static void backoff() {

--- a/app/src/test/java/com/eveningoutpost/dexdrip/RefusingContext.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/RefusingContext.java
@@ -1,0 +1,44 @@
+package com.eveningoutpost.dexdrip;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stands in for the platform when it refuses to start a service.
+ * <p>
+ * Records what was asked for, then refuses it the way Android refuses a background process from
+ * target SDK 26. Everything else, {@code stopService} and preferences included, goes to the real
+ * context underneath.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public final class RefusingContext extends ContextWrapper {
+
+    private final List<Intent> attempted = new ArrayList<>();
+
+    public RefusingContext(final Context base) {
+        super(base);
+    }
+
+    /** Every intent {@code startService} was called with, in the order it was called. */
+    public List<Intent> attempted() {
+        return attempted;
+    }
+
+    /** The class an intent targets, or null if it carries no explicit component. */
+    public static String targetClassOf(final Intent intent) {
+        final ComponentName component = intent.getComponent();
+        return component == null ? null : component.getClassName();
+    }
+
+    @Override
+    public ComponentName startService(final Intent service) {
+        attempted.add(service);
+        throw new IllegalStateException("Not allowed to start service " + service + ": app is in background");
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHStartServiceTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/models/JoHStartServiceTest.java
@@ -1,0 +1,106 @@
+package com.eveningoutpost.dexdrip.models;
+
+import android.content.Intent;
+
+import com.eveningoutpost.dexdrip.RefusingContext;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.services.MissedReadingService;
+import com.eveningoutpost.dexdrip.services.PlusSyncService;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Covers {@link JoH#startService} when Android refuses the start.
+ * <p>
+ * From target SDK 26 a process that Android started to deliver a broadcast counts as being in the
+ * background, so {@code Context.startService} throws instead of starting anything. Most callers
+ * reach this method through {@code Inevitable}, which runs the task on a plain thread with nothing
+ * catching what it throws, so the refusal took the whole process down from a worker thread. These
+ * tests pin the caller-visible half of that: a refused start must not propagate, and it must not
+ * stop whatever the caller does next.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class JoHStartServiceTest extends RobolectricTestWithConfig {
+
+    private RefusingContext refusing;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        refusing = new RefusingContext(RuntimeEnvironment.application);
+        xdrip.setContextAlways(refusing);
+    }
+
+    @After
+    public void tearDown() {
+        xdrip.setContextAlways(RuntimeEnvironment.application);
+    }
+
+    // ============================================ startService ==============================================
+
+    /** The start is attempted against the right service and the refusal stays inside JoH. */
+    @Test
+    public void startServiceAttemptsTheStartAndSwallowsTheRefusal() {
+        // :: Act
+        JoH.startService(MissedReadingService.class);
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        assertWithMessage("target service")
+                .that(RefusingContext.targetClassOf(refusing.attempted().get(0)))
+                .isEqualTo(MissedReadingService.class.getName());
+    }
+
+    /** A refused start must not stop the caller from getting to its next statement. */
+    @Test
+    public void aRefusedStartDoesNotStopTheNextOne() {
+        // :: Act
+        JoH.startService(PlusSyncService.class);
+        JoH.startService(MissedReadingService.class);
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(2);
+        assertWithMessage("first target")
+                .that(RefusingContext.targetClassOf(refusing.attempted().get(0)))
+                .isEqualTo(PlusSyncService.class.getName());
+        assertWithMessage("second target")
+                .that(RefusingContext.targetClassOf(refusing.attempted().get(1)))
+                .isEqualTo(MissedReadingService.class.getName());
+    }
+
+    /** The argument overload builds its intent as usual and survives the refusal the same way. */
+    @Test
+    public void startServiceWithArgumentsStillCarriesThemWhenRefused() {
+        // :: Act
+        JoH.startService(MissedReadingService.class, "function", "test", "count", "2");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        final Intent attempted = refusing.attempted().get(0);
+        assertWithMessage("function extra").that(attempted.getStringExtra("function")).isEqualTo("test");
+        assertWithMessage("count extra").that(attempted.getStringExtra("count")).isEqualTo("2");
+    }
+
+    /** An odd argument count is a programming error and must still be reported, not swallowed. */
+    @Test
+    public void startServiceStillRejectsAnOddNumberOfArguments() {
+        // :: Act
+        try {
+            JoH.startService(MissedReadingService.class, "function");
+            assertWithMessage("odd argument count was accepted").fail();
+        } catch (RuntimeException e) {
+            // :: Verify
+            assertWithMessage("reason").that(e.getMessage()).contains("Odd number of args");
+        }
+        assertWithMessage("no start attempted").that(refusing.attempted()).isEmpty();
+    }
+
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/ActivityRecognizedServiceStartTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/ActivityRecognizedServiceStartTest.java
@@ -1,0 +1,64 @@
+package com.eveningoutpost.dexdrip.services;
+
+import android.content.Intent;
+
+import com.eveningoutpost.dexdrip.RefusingContext;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Covers {@link ActivityRecognizedService#startActivityRecogniser} when Android refuses the start.
+ * <p>
+ * This runs from {@code xdrip.onCreate} for anyone with motion tracking switched on, two lines after
+ * the sync service. In a process Android started only to deliver a broadcast the start is refused at
+ * target SDK 26, and an unguarded refusal here takes the process down just as surely as one further
+ * up. Motion tracking simply stays off on such a process until the app is brought up in its own right.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class ActivityRecognizedServiceStartTest extends RobolectricTestWithConfig {
+
+    private RefusingContext refusing;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        refusing = new RefusingContext(RuntimeEnvironment.application);
+    }
+
+    // ======================================= startActivityRecogniser ========================================
+
+    /** The start is attempted against the recogniser, carrying its action, and the refusal stays inside. */
+    @Test
+    public void startActivityRecogniserAttemptsTheStartAndSwallowsTheRefusal() {
+        // :: Act
+        ActivityRecognizedService.startActivityRecogniser(refusing);
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        final Intent attempted = refusing.attempted().get(0);
+        assertWithMessage("target service")
+                .that(RefusingContext.targetClassOf(attempted))
+                .isEqualTo(ActivityRecognizedService.class.getName());
+        assertWithMessage("start action")
+                .that(attempted.getStringExtra("START_ACTIVITY_ACTION"))
+                .isEqualTo("START_ACTIVITY_ACTION");
+    }
+
+    /** A refused start must not stop the caller from getting to its next statement. */
+    @Test
+    public void aRefusedStartDoesNotStopTheNextOne() {
+        // :: Act
+        ActivityRecognizedService.startActivityRecogniser(refusing);
+        ActivityRecognizedService.startActivityRecogniser(refusing);
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(2);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeterStartTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/BluetoothGlucoseMeterStartTest.java
@@ -1,0 +1,86 @@
+package com.eveningoutpost.dexdrip.services;
+
+import android.content.Intent;
+
+import com.eveningoutpost.dexdrip.RefusingContext;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Covers {@link BluetoothGlucoseMeter#start_service} when Android refuses the start.
+ * <p>
+ * This runs from {@code xdrip.onCreate} for anyone with a Bluetooth meter paired, four lines after
+ * the sync service, and it is the last unguarded synchronous service start in that block. At target
+ * SDK 26 a process started only to deliver a broadcast may not start it, and an unguarded refusal
+ * here takes the process down. The meter connects as usual the next time the app comes up itself.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class BluetoothGlucoseMeterStartTest extends RobolectricTestWithConfig {
+
+    private RefusingContext refusing;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        refusing = new RefusingContext(RuntimeEnvironment.application);
+        xdrip.setContextAlways(refusing);
+    }
+
+    @After
+    public void tearDown() {
+        xdrip.setContextAlways(RuntimeEnvironment.application);
+    }
+
+    // ============================================ start_service =============================================
+
+    /** A start for a known meter carries the connect address and the refusal stays inside the method. */
+    @Test
+    public void startServiceAttemptsTheConnectAndSwallowsTheRefusal() {
+        // :: Act
+        BluetoothGlucoseMeter.start_service("AA:BB:CC:DD:EE:FF");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        final Intent attempted = refusing.attempted().get(0);
+        assertWithMessage("target service")
+                .that(RefusingContext.targetClassOf(attempted))
+                .isEqualTo(BluetoothGlucoseMeter.class.getName());
+        assertWithMessage("service action").that(attempted.getStringExtra("service_action")).isEqualTo("connect");
+        assertWithMessage("connect address")
+                .that(attempted.getStringExtra("connect_address"))
+                .isEqualTo("AA:BB:CC:DD:EE:FF");
+    }
+
+    /** With no address to connect to the meter is asked to scan, and a refusal is still swallowed. */
+    @Test
+    public void startServiceAttemptsAScanWhenNoAddressIsGiven() {
+        // :: Act
+        BluetoothGlucoseMeter.start_service("");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        assertWithMessage("service action")
+                .that(refusing.attempted().get(0).getStringExtra("service_action"))
+                .isEqualTo("scan");
+    }
+
+    /** A refused start must not stop the caller from getting to its next statement. */
+    @Test
+    public void aRefusedStartDoesNotStopTheNextOne() {
+        // :: Act
+        BluetoothGlucoseMeter.start_service("AA:BB:CC:DD:EE:FF");
+        BluetoothGlucoseMeter.start_service("AA:BB:CC:DD:EE:FF");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(2);
+    }
+}

--- a/app/src/test/java/com/eveningoutpost/dexdrip/services/PlusSyncServiceBackgroundStartTest.java
+++ b/app/src/test/java/com/eveningoutpost/dexdrip/services/PlusSyncServiceBackgroundStartTest.java
@@ -1,0 +1,103 @@
+package com.eveningoutpost.dexdrip.services;
+
+import android.preference.PreferenceManager;
+
+import com.eveningoutpost.dexdrip.GcmActivity;
+import com.eveningoutpost.dexdrip.RefusingContext;
+import com.eveningoutpost.dexdrip.RobolectricTestWithConfig;
+import com.eveningoutpost.dexdrip.xdrip;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Covers {@link PlusSyncService#startSyncService} when Android refuses the start.
+ * <p>
+ * This is the first service {@code xdrip.onCreate} starts on its own stack, so in a process Android
+ * started only to deliver a broadcast it is the first thing to hit the target SDK 26 background
+ * restriction: that process counts as being in the background, {@code Context.startService} throws,
+ * and the process died before the receiver ever ran. The sync service simply does not start on such
+ * a process; it starts as usual the next time the app or a collector brings the process up itself.
+ *
+ * @author Asbjørn Aarrestad
+ */
+public class PlusSyncServiceBackgroundStartTest extends RobolectricTestWithConfig {
+
+    private RefusingContext refusing;
+    private boolean createdBefore;
+    private String tokenBefore;
+    private boolean ceaseBefore;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        xdrip.setContextAlways(RuntimeEnvironment.application);
+
+        createdBefore = PlusSyncService.created;
+        tokenBefore = GcmActivity.token;
+        ceaseBefore = GcmActivity.cease_all_activity;
+        PlusSyncService.created = false;
+        GcmActivity.token = null;
+        GcmActivity.cease_all_activity = false;
+
+        refusing = new RefusingContext(RuntimeEnvironment.application);
+        PreferenceManager.getDefaultSharedPreferences(refusing).edit().clear().commit();
+    }
+
+    @After
+    public void tearDown() {
+        PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application).edit().clear().commit();
+        PlusSyncService.created = createdBefore;
+        GcmActivity.token = tokenBefore;
+        GcmActivity.cease_all_activity = ceaseBefore;
+        xdrip.setContextAlways(RuntimeEnvironment.application);
+    }
+
+    // ========================================== startSyncService ============================================
+
+    /** The start is attempted against the sync service and the refusal stays inside the method. */
+    @Test
+    public void startSyncServiceAttemptsTheStartAndSwallowsTheRefusal() {
+        // :: Act
+        PlusSyncService.startSyncService(refusing, "test");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(1);
+        assertWithMessage("target service")
+                .that(RefusingContext.targetClassOf(refusing.attempted().get(0)))
+                .isEqualTo(PlusSyncService.class.getName());
+    }
+
+    /** A refused start must leave nothing latched behind that would block the attempt after it. */
+    @Test
+    public void aRefusedStartDoesNotStopTheNextOne() {
+        // :: Act
+        PlusSyncService.startSyncService(refusing, "first");
+        PlusSyncService.startSyncService(refusing, "second");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).hasSize(2);
+        assertWithMessage("service marked as created").that(PlusSyncService.created).isFalse();
+    }
+
+    /** With sync switched off nothing is attempted at all - the guard must not change that. */
+    @Test
+    public void startSyncServiceAttemptsNothingWhenSyncIsDisabled() {
+        // :: Setup
+        PreferenceManager.getDefaultSharedPreferences(refusing)
+                .edit().putBoolean("disable_all_sync", true).commit();
+
+        // :: Act
+        PlusSyncService.startSyncService(refusing, "test");
+
+        // :: Verify
+        assertWithMessage("attempted starts").that(refusing.attempted()).isEmpty();
+        assertWithMessage("all activity ceased").that(GcmActivity.cease_all_activity).isTrue();
+    }
+
+}


### PR DESCRIPTION
Row 3 of the table in #4676 - this is that fix.

## Problem

targetSdkVersion went 24 -> 26 in #4601. From 26 a process that Android started only to
deliver a broadcast counts as being in the background, so Context.startService throws
instead of starting anything.

xdrip.onCreate starts services unconditionally. On such a process the throw was uncaught
and the process died before the receiver ran. Putting the receivers back in the manifest
routes traffic into that path, so the guards need to be in place first.

## What is guarded

Four call sites reachable from xdrip.onCreate:

- `JoH.startService(Class)` and `JoH.startService(Class, byte[], String...)`
- `PlusSyncService.startSyncService` - xdrip.java:142
- `ActivityRecognizedService.startActivityRecogniser` - xdrip.java:144, motion tracking on
- `BluetoothGlucoseMeter.start_service` - xdrip.java:146, meter paired

The two JoH overloads carry most of it. Everything deferred through Inevitable goes
through them, and `Inevitable.poll` calls `what.run()` on a plain thread with no catch, so
a refused start there took the process down from a worker thread rather than on onCreate's
stack.

The intent is built outside the try everywhere, so only the start itself is guarded. An
odd argument count in `JoH.startService` still throws as before.

## Logging

`UserError.Log.e` behind `JoH.ratelimit`, once an hour. Same as AutoStart, which already
wraps `startSyncService` this way. These paths carry watch alerts, so a dropped start has
to leave something in the event log; the rate limit keeps a phone stuck in a
background-restricted state from filling it.

## Tests

    ./gradlew :app:testFastDebugUnitTest :wear:testFastDebugUnitTest

All green. The new tests drive each guarded call site through a ContextWrapper that refuses
startService the way the platform does.
